### PR TITLE
Valide la sécurité de l'environnement d'Intégration Continue

### DIFF
--- a/.github/workflows/deploiement.yml
+++ b/.github/workflows/deploiement.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0 # Cloner l'intégralité du dépôt, pour ne pas avoir de « shallow repo » rejeté par Clever
+          persist-credentials: false
 
       - name: Installer la CLI Clever Cloud
         shell: bash
@@ -41,6 +42,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0 # Cloner l'intégralité du dépôt, pour ne pas avoir de « shallow repo » rejeté par Clever
+          persist-credentials: false
 
       - name: Installer la CLI Clever Cloud
         shell: bash

--- a/.github/workflows/securite-ci.yml
+++ b/.github/workflows/securite-ci.yml
@@ -1,0 +1,57 @@
+# Vérification des recommandations CIs et autres sur les configurations GitHub
+# https://www.checkov.io/1.Welcome/What%20is%20Checkov.html
+# https://github.com/bridgecrewio/checkov-action
+# https://docs.zizmor.sh/
+---
+name: Sécurité de la CI
+permissions: {}
+on:
+  push:
+    branches: ['main', 'master']
+  pull_request:
+    branches: ['main', 'master']
+
+  workflow_dispatch:
+
+jobs:
+  checkov:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Checkov GitHub Action
+        uses: bridgecrewio/checkov-action@fa9edf8f0a491c59a924ea6accd5bdcf07752cff # v12.3107.0
+        with:
+          output_format: cli,sarif
+          output_file_path: console,results.sarif
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
+
+        if: success() || failure()
+        with:
+          sarif_file: results.sarif
+
+  zizmor:
+    name: zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: zizmor GitHub Action
+        uses: zizmorcore/zizmor-action@e639db99335bc9038abc0e066dfcd72e23d26fb4 # v0.3.0
+        with:
+          advanced-security: true


### PR DESCRIPTION
On ajoute `checkov` et `zizmor`.

On en profite pour apporter les corrections proposées par l'outil, histoire de commencer avec une CI verte.